### PR TITLE
Feature/homepage scroll

### DIFF
--- a/src/spa/css/global.css
+++ b/src/spa/css/global.css
@@ -104,6 +104,8 @@ a:hover, .pretend-link:hover {
     height: 100vh;
     z-index: 999!important;
     position: fixed;
+    left: 0;
+    top: 0;
     background-color: rgba(255,255,255,0.9);
     color: var(--trip-orange);
     display: flex;

--- a/src/spa/css/snap-scroll.module.css
+++ b/src/spa/css/snap-scroll.module.css
@@ -1,17 +1,34 @@
 .container {
     overflow-y: auto;
     overflow-x: hidden;
-    scroll-snap-type: y mandatory;
-
 }
 
 .slide {
-    height: calc(100vh - 3em);
+    height: calc(88vh);
     width: 100vw;
     box-sizing: border-box;
-    scroll-snap-align: center;
     position: relative;
     outline: solid #eee 2px;
+}
+
+@media screen and (max-width: 700px) {
+    .container {
+        scroll-snap-type: y mandatory;
+    }
+    .slide {
+        height: calc(100vh - 3em);
+        scroll-snap-align: center;
+    }
+}
+
+@media screen and (min-width: 700px){
+    .container > div:nth-child(2) {
+         background-color: #efefef;
+     }
+    .container > div:nth-child(3) {
+        background-color: #e1e1e1;
+    }
+
 
 }
 


### PR DESCRIPTION
Remove the snap-scroll behaviour of homepage on desktop
change the height and background of the blocks to attract the user to keep scrolling