### PR TITLE
Create API endpoint for getting trip index

### DIFF
--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -8,13 +8,102 @@ use Illuminate\Http\Request;
 class TripController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Display a listing of all trips of the currently
+     * logged in user.
      *
+     * @param Request $request
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        //
+        $trips = $request->user()->trips();
+
+        $vm = $trips->map(function($trip) {
+            return [
+                'id' => $trip->id,
+                'name' => $trip->name,
+                'updated' => true,
+            ];
+        });
+
+        return response()->json($vm);
+    }
+
+    /**
+     * Display a listing of all current trips of the
+     * currently logged in user.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function currentTrips(Request $request)
+    {
+        $trips = $request->user()->trips()
+            ->where([
+                ['start_date', '<=', now()],
+                ['end_date', '>=', now()],
+            ])
+            ->values();
+
+        $vm = $trips->map(function($trip) {
+            return [
+                'id' => $trip->id,
+                'name' => $trip->name,
+                'updated' => true,
+            ];
+        });
+
+        return response()->json($vm);
+    }
+
+    /**
+     * Display a listing of all past trips of the
+     * currently logged in user.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function pastTrips(Request $request)
+    {
+        $trips = $request->user()->trips()
+            ->where('end_date', '<', now())
+            ->values();
+
+        $vm = $trips->map(function($trip) {
+            return [
+                'id' => $trip->id,
+                'name' => $trip->name,
+                'updated' => true,
+            ];
+        });
+
+        return response()->json($vm);
+    }
+
+    /**
+     * Display a listing of all future trips of the
+     * currently logged in user.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function futureTrips(Request $request)
+    {
+        $trips = $request->user()->trips()
+            ->where([
+                ['start_date', '>', now()],
+            ])
+            ->values();
+
+        $vm = $trips->map(function($trip) {
+            return [
+                'id' => $trip->id,
+                'name' => $trip->name,
+                'updated' => true,
+            ];
+        });
+
+        return response()->json($vm);
     }
 
     /**

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -13,6 +13,11 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+Route::get('/trips', 'TripController@index');
+Route::get('/trips/past', 'TripController@pastTrips');
+Route::get('/trips/current', 'TripController@currentTrips');
+Route::get('/trips/future', 'TripController@futureTrips');
+
 Route::post('/login', 'UserController@login');
 Route::post('/register', 'UserController@register');
 Route::get('/logout', 'UserController@logout');


### PR DESCRIPTION
This adds new API routes for the front-end to retrieve an index of trips stored within the database.

These are:

- `/trips`
  - Returns an array of all trips the currently logged in user has created
- `/trips/past`
  - Returns an array of all trips that has `end_date` before today
- `/trips/current`
  - Returns an array of all trips that has start date before today (and today) and end date after today (or today)
- `/trips/future`
  - Returns an array of all trips that has start date after today

All responses are returned within the following JSON format:
```
[
  {
    id: 1,
    name: 'testName'
    updated: true
  }
]
```

**Note:** Currently last updated functionality has not been implemented

Closes #47