### PR TITLE
API to check existence of e-mail address

### DIFF
--- a/src/api/app/Http/Controllers/UserController.php
+++ b/src/api/app/Http/Controllers/UserController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers;
 use App\Http\Requests\CreateUserRequest;
 use App\User;
 use Illuminate\Http\Request;
-
 use Auth;
+use Hash;
 
 class UserController extends Controller
 {
@@ -39,13 +39,11 @@ class UserController extends Controller
      */
     public function register(CreateUserRequest $request)
     {
-        User::create([
+        $user = User::create([
             'name' => $request['name'],
             'email' => $request['email'],
             'password' => Hash::make($request['password']),
         ]);
-
-        $user = $this->create($request);
 
         Auth::guard()->login($user);
 

--- a/src/api/app/Http/Controllers/UserController.php
+++ b/src/api/app/Http/Controllers/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\CreateUserRequest;
+use App\User;
 use Illuminate\Http\Request;
 
 use Auth;
@@ -15,8 +16,20 @@ class UserController extends Controller
             ['except' => [
                 'register',
                 'login',
-                'logout'
+                'logout',
+                'checkExists'
             ]]);
+    }
+
+    /**
+     * Checks if a user already exists within the database
+     * @param User $user
+     * @return \Illuminate\Http\Response
+     */
+    public function checkExists(User $user)
+    {
+        // If User is not in database, Laravel Route Model Binding will automatically return 404
+        return response(null, 200);
     }
 
     /**

--- a/src/api/app/Http/Requests/CreateUserRequest.php
+++ b/src/api/app/Http/Requests/CreateUserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'min:4', 'confirmed'],
+        ];
+    }
+}

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -20,3 +20,4 @@ Route::post('/register', 'UserController@register');
 Route::get('/logout', 'UserController@logout');
 
 Route::get('/user', 'UserController@show');
+Route::match('head', '/user/email/{user:email}', 'UserController@checkExists');

--- a/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
@@ -131,20 +131,19 @@ class TripControllerTest extends TestCase
 
         $response = $this->actingAs($users->random())->json('get', "/api/trip/$trip->id");
 
-        $response->assertStatus(200)
-            ->assertJsonFragment([
-                'name' => $trip->name,
-                'description' => $trip->description,
-                'participants' => $users->map(function ($user) {
-                    return [
-                        'avatarPath' => $user->avatar_url,
-                        'email' => $user->email,
-                        'id' => $user->id,
-                        'name' => $user->name,
-                    ];
-                }),
-                'start' => $tomorrow->toDateTimeString(),
-                'end' => $weekAfter->toDateTimeString(),
+        $response->assertStatus(200);
+
+        $this->assertEquals($trip->name, $response['name']);
+        $this->assertEquals($trip->description, $response['description']);
+        $this->assertEquals($tomorrow->toDateTimeString(), $response['start']);
+        $this->assertEquals($weekAfter->toDateTimeString(), $response['end']);
+        $users->each(function ($user) use ($response) {
+            $response->assertJsonFragment([
+                'avatarPath' => $user->avatar_url,
+                'email' => $user->email,
+                'id' => $user->id,
+                'name' => $user->name,
             ]);
+        });
     }
 }

--- a/src/api/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function checks_for_an_existing_user()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->json('head', "/api/user/email/$user->email");
+
+        $response->assertStatus(200);
+    }
+
+    /** @test */
+    public function checks_for_a_nonexisting_user()
+    {
+        $response = $this->json('head', "/api/user/email/nonexistinguser@domain.com");
+
+        $response->assertStatus(404);
+    }
+
+    /** @test */
+    public function is_able_to_register_a_user()
+    {
+        $response = $this->json('post', "/api/register", [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+            'password' => 'newUserPassword',
+            'password_confirmation' => 'newUserPassword',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('users', [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+        ]);
+    }
+
+    /** @test */
+    public function rejects_registration_attempt_with_different_confirmed_password()
+    {
+        $response = $this->json('post', "/api/register", [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+            'password' => 'newUserPassword',
+            'password_confirmation' => 'obviouslyDifferentHere',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertDatabaseMissing('users', [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+        ]);
+    }
+
+    /** @test */
+    public function rejects_registration_attempt_with_invalid_email()
+    {
+        $response = $this->json('post', "/api/register", [
+            'email' => 'newuser',
+            'name' => 'New User',
+            'password' => 'newUserPassword',
+            'password_confirmation' => 'newUserPassword',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertDatabaseMissing('users', [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+        ]);
+    }
+
+    /** @test */
+    public function rejects_registration_attempt_with_missing_request_body_fields()
+    {
+        $response = $this->json('post', "/api/register", [
+            'name' => 'New User',
+            'password' => 'newUserPassword',
+            'password_confirmation' => 'newUserPassword',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertDatabaseMissing('users', [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds a new API route for checking whether an e-mail address has already been registered or not along with tests to be run using PHPUnit.

**Usage:**
Submit a HEAD request to `/api/user/{email}`. If user exists, a 200 OK response is returned, otherwise a 404 Not Found response is returned.

Closes #55 