### PR TITLE
API to get all activities and travels associated with a particular trip ID

### DIFF
--- a/src/api/app/Activity.php
+++ b/src/api/app/Activity.php
@@ -15,6 +15,28 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity query()
  * @mixin \Eloquent
+ * @property int $id
+ * @property string $type
+ * @property string $name
+ * @property string $description
+ * @property string $start_time
+ * @property string $end_time
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property int $trip_id
+ * @property string $location_coordinates
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\User[] $users
+ * @property-read int|null $users_count
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereEndTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereLocationCoordinates($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereStartTime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereTripId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Activity whereUpdatedAt($value)
  */
 class Activity extends Model
 {
@@ -43,5 +65,14 @@ class Activity extends Model
     public function notes()
     {
         return $this->morphMany(Note::class, 'pointer');
+    }
+
+    /**
+     * Gets the users who are joining this activity
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     */
+    public function users()
+    {
+        return $this->morphToMany(User::class, 'pointer', 'user_pointer');
     }
 }

--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -166,6 +166,56 @@ class TripController extends Controller
         return response()->json($vm);
     }
 
+    public function showActivities(Trip $trip)
+    {
+        $activities = $trip->activities;
+
+        $vmActivities = $activities->map(function ($activity) {
+            $location = $activity->location;
+
+            $fullCoordinates = $location->coordinates;
+            $coordinates = explode(', ', $fullCoordinates);
+            $lat = $coordinates[0];
+            $lng = $coordinates[1];
+
+            return [
+                'id' => $activity->id,
+                'type' => $activity->type,
+                'start' => $activity->start_time,
+                'end' => $activity->end_time,
+                'name' => $activity->name,
+                'description' => $activity->description,
+                'updated' => $activity->updated_at,
+                'address' => $location->address,
+                'gps' => [
+                    'lat' => $lat,
+                    'lng' => $lng,
+                ],
+                'people' => $activity->users->map(function ($user) {
+                    return [
+                        'id' => $user->id,
+                        'name' => $user->name,
+                        'avatarPath' => $user->avatar_url,
+                    ];
+                }),
+                'notes' => $activity->notes->map(function ($note) {
+                    return [
+                        'id' => $note->id,
+                        'author' => [
+                            'id' => $note->user->id,
+                            'name' => $note->user->name,
+                            'avatarPath' => $note->user->avatar_url,
+                        ],
+                        'content' => $note->body,
+                        'updated' => $note->updated_at
+                    ];
+                }),
+            ];
+        });
+
+        return $vmActivities;
+    }
+
     /**
      * Show the form for editing the specified resource.
      *

--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -166,6 +166,11 @@ class TripController extends Controller
         return response()->json($vm);
     }
 
+    /**
+     * Display all activities associated with the given Trip
+     * @param Trip $trip
+     * @return \App\Activity[]|\Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection
+     */
     public function showActivities(Trip $trip)
     {
         $activities = $trip->activities;
@@ -199,6 +204,65 @@ class TripController extends Controller
                     ];
                 }),
                 'notes' => $activity->notes->map(function ($note) {
+                    return [
+                        'id' => $note->id,
+                        'author' => [
+                            'id' => $note->user->id,
+                            'name' => $note->user->name,
+                            'avatarPath' => $note->user->avatar_url,
+                        ],
+                        'content' => $note->body,
+                        'updated' => $note->updated_at
+                    ];
+                }),
+            ];
+        });
+
+        return $vmActivities;
+    }
+
+    /**
+     * Display all travels associated with the given Trip
+     * @param Trip $trip
+     * @return \App\Travel[]|\Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection
+     */
+    public function showTravels(Trip $trip)
+    {
+        $travels = $trip->travels;
+
+        $vmActivities = $travels->map(function ($travel) {
+            $fromLocation = $travel->from;
+            $fromCoords = explode(', ', $fromLocation->coordinates);
+            $fromLat = $fromCoords[0];
+            $fromLng = $fromCoords[1];
+
+            $toLocation = $travel->to;
+            $toCoords = explode(', ', $toLocation->coordinates);
+            $toLat = $toCoords[0];
+            $toLng = $toCoords[1];
+
+            return [
+                'id' => $travel->id,
+                'start' => $travel->start,
+                'end' => $travel->end,
+                'mode' => $travel->mode,
+                'description' => $travel->description,
+                'from' => [
+                    'lat' => $fromLat,
+                    'lng' => $fromLng,
+                ],
+                'to' => [
+                    'lat' => $toLat,
+                    'lng' => $toLng,
+                ],
+                'people' => $travel->users->map(function ($user) {
+                    return [
+                        'id' => $user->id,
+                        'name' => $user->name,
+                        'avatarPath' => $user->avatar_url,
+                    ];
+                }),
+                'notes' => $travel->notes->map(function ($note) {
                     return [
                         'id' => $note->id,
                         'author' => [

--- a/src/api/app/Location.php
+++ b/src/api/app/Location.php
@@ -11,6 +11,18 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Location newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Location query()
  * @mixin \Eloquent
+ * @property int $id
+ * @property string $name
+ * @property string $address
+ * @property string $coordinates
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Location whereAddress($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Location whereCoordinates($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Location whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Location whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Location whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Location whereUpdatedAt($value)
  */
 class Location extends Model
 {

--- a/src/api/app/Message.php
+++ b/src/api/app/Message.php
@@ -13,6 +13,20 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Message newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Message query()
  * @mixin \Eloquent
+ * @property int $id
+ * @property string $body
+ * @property int $user_id
+ * @property int $trip_id
+ * @property string|null $deleted_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Message whereBody($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Message whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Message whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Message whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Message whereTripId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Message whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Message whereUserId($value)
  */
 class Message extends Model
 {

--- a/src/api/app/Note.php
+++ b/src/api/app/Note.php
@@ -13,6 +13,20 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Note newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Note query()
  * @mixin \Eloquent
+ * @property int $id
+ * @property string $body
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property int $user_id
+ * @property int $pointer_id
+ * @property string $pointer_type
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Note whereBody($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Note whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Note whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Note wherePointerId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Note wherePointerType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Note whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Note whereUserId($value)
  */
 class Note extends Model
 {

--- a/src/api/app/Travel.php
+++ b/src/api/app/Travel.php
@@ -16,6 +16,26 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel query()
  * @mixin \Eloquent
+ * @property int $id
+ * @property string $mode
+ * @property string $description
+ * @property string $start
+ * @property string $end
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property int $trip_id
+ * @property string $from_coordinates
+ * @property string $to_coordinates
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereEnd($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereFromCoordinates($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereMode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereStart($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereToCoordinates($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereTripId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereUpdatedAt($value)
  */
 class Travel extends Model
 {

--- a/src/api/app/Travel.php
+++ b/src/api/app/Travel.php
@@ -74,4 +74,13 @@ class Travel extends Model
     {
         return $this->morphMany(Note::class, 'pointer');
     }
+
+    /**
+     * Gets the users who are joining this travel
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     */
+    public function users()
+    {
+        return $this->morphToMany(User::class, 'pointer', 'user_pointer');
+    }
 }

--- a/src/api/app/User.php
+++ b/src/api/app/User.php
@@ -113,4 +113,13 @@ class User extends Authenticatable
     {
         return $this->morphedByMany(Activity::class, 'pointer', 'user_pointer');
     }
+
+    /**
+     * Gets all travels this user is party to
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     */
+    public function travels()
+    {
+        return $this->morphedByMany(Travel::class, 'pointer', 'user_pointer');
+    }
 }

--- a/src/api/app/User.php
+++ b/src/api/app/User.php
@@ -37,6 +37,8 @@ use Illuminate\Notifications\Notifiable;
  * @property-read int|null $trips_count
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Message[] $messages
  * @property-read int|null $messages_count
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Activity[] $activities
+ * @property-read int|null $activities_count
  */
 class User extends Authenticatable
 {
@@ -91,10 +93,24 @@ class User extends Authenticatable
         return $this->hasMany(Message::class);
     }
 
+    /**
+     * Gets the last checked DateTime stamp for a particular trip
+     * @param Trip $trip
+     * @return mixed
+     */
     public function lastChecked(Trip $trip)
     {
         return $this->belongsToMany(Trip::class, 'user_trip')
             ->where('trip_id', $trip->id)
             ->value('last_checked_trip');
+    }
+
+    /**
+     * Gets all activities this user is party to
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     */
+    public function activities()
+    {
+        return $this->morphedByMany(Activity::class, 'pointer', 'user_pointer');
     }
 }

--- a/src/api/database/migrations/2020_05_03_123113_create_user_pointer.php
+++ b/src/api/database/migrations/2020_05_03_123113_create_user_pointer.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserPointer extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_pointer', function (Blueprint $table) {
+            $table->id();
+
+            $table->timestamps();
+
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('pointer_id');
+            $table->string('pointer_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_pointer');
+    }
+}

--- a/src/api/database/seeds/DatabaseSeeder.php
+++ b/src/api/database/seeds/DatabaseSeeder.php
@@ -20,6 +20,7 @@ class DatabaseSeeder extends Seeder
              TravelSeeder::class,
              NoteSeeder::class,
              MessageSeeder::class,
+             UserPointerSeeder::class,
          ]);
     }
 }

--- a/src/api/database/seeds/UserPointerSeeder.php
+++ b/src/api/database/seeds/UserPointerSeeder.php
@@ -12,7 +12,6 @@ class UserPointerSeeder extends Seeder
     public function run()
     {
         $faker = \Faker\Factory::create();
-
         $pointers = [
             \App\Activity::class,
             \App\Travel::class,
@@ -20,12 +19,17 @@ class UserPointerSeeder extends Seeder
 
         \App\User::all()->each(function ($user) use ($pointers, $faker) {
 
-            $pointerType = $faker->randomElement($pointers);
-            $pointer = $pointerType::all()->random();
+            for ($i = 0; $i < rand(0, 4); $i++) {
+                // Choose a random Travel/Activity from DB
+                $pointerType = $faker->randomElement($pointers);
+                $pointer = $pointerType::all()->random();
 
-            $user->activities()->attach(
-                $pointer->id
-            );
+                DB::table('user_pointer')->insert([
+                    'user_id' => $user->id,
+                    'pointer_id' => $pointer->id,
+                    'pointer_type' => $pointerType
+                ]);
+            }
         });
     }
 }

--- a/src/api/database/seeds/UserPointerSeeder.php
+++ b/src/api/database/seeds/UserPointerSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UserPointerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $faker = \Faker\Factory::create();
+
+        $pointers = [
+            \App\Activity::class,
+            \App\Travel::class,
+        ];
+
+        \App\User::all()->each(function ($user) use ($pointers, $faker) {
+
+            $pointerType = $faker->randomElement($pointers);
+            $pointer = $pointerType::all()->random();
+
+            $user->activities()->attach(
+                $pointer->id
+            );
+        });
+    }
+}

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -12,6 +12,7 @@ Route::get('/trips/future', 'TripController@futureTrips');
 
 Route::get('/trip/{trip}', 'TripController@show');
 Route::get('/trip/{trip}/activities', 'TripController@showActivities');
+Route::get('/trip/{trip}/travels', 'TripController@showTravels');
 
 /*
  * UserController

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -11,6 +11,7 @@ Route::get('/trips/current', 'TripController@currentTrips');
 Route::get('/trips/future', 'TripController@futureTrips');
 
 Route::get('/trip/{trip}', 'TripController@show');
+Route::get('/trip/{trip}/activities', 'TripController@showActivities');
 
 /*
  * UserController

--- a/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Feature\Http\Controllers;
 
+use App\Activity;
+use App\Location;
+use App\Note;
 use App\Trip;
 use App\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -145,5 +148,59 @@ class TripControllerTest extends TestCase
                 'name' => $user->name,
             ]);
         });
+    }
+
+    /** @test */
+    public function gets_activities_tied_to_a_trip()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $location = factory(Location::class)->create([
+            'coordinates' => '100.22, 20.36'
+        ]);
+        $activity = factory(Activity::class)->create();
+        $user->activities()->attach($activity);
+        // Force create Note tied to an Activity instead of a Travel
+        $note = factory(Note::class)->create([
+            'pointer_id' => $activity->id,
+            'pointer_type' => Activity::class
+        ]);
+
+        $response = $this->actingAs($user)->json('get', "/api/trip/$trip->id/activities");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'id' => $activity->id,
+                'type' => $activity->type,
+                'start' => $activity->start_time->format('Y-m-d H:i:s'),
+                'end' => $activity->end_time->format('Y-m-d H:i:s'),
+                'name' => $activity->name,
+                'description' => $activity->description,
+                'updated' => $activity->updated_at,
+                'address' => $location->address,
+                'gps' => [
+                    'lat' => '100.22',
+                    'lng' => '20.36',
+                ],
+                'people' => [
+                    [
+                        'id' => $user->id,
+                        'name' => $user->name,
+                        'avatarPath' => $user->avatar_url
+                    ]
+                ],
+                'notes' => [
+                    [
+                        'id' => $note->id,
+                        'author' => [
+                            'id' => $user->id,
+                            'name' => $user->name,
+                            'avatarPath' => $user->avatar_url
+                        ],
+                        'content' => $note->body,
+                        'updated' => $note->updated_at
+                    ]
+                ]
+            ]);
     }
 }


### PR DESCRIPTION
- [X] An API endpoint will be created.
- [X] The API endpoint will take a trip's ID, and return the activities and travels that belong to the trip.
- [X] The data structure should be similar to dummy data for activities and travels.
- [X] There should be a field to differentiate between activity and travel.
  - Activities can be retrieved by GET `/api/trip/{id}/activities`
  - Travels can be retrieved by GET `/api/trip/{id}/travels`
- [X] I would like to have id of people too, although it's not in dummy data.

Closes #51.