### PR TITLE
API to create a trip

### DIFF
--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -10,6 +10,7 @@ class TripController extends Controller
 {
     public function __construct()
     {
+        $this->middleware('auth:sanctum');
         // TODO: Incorporate Laravel Resources to transform Model to JSON
     }
 
@@ -133,7 +134,31 @@ class TripController extends Controller
      */
     public function store(CreateTripRequest $request)
     {
-        return response()->json('hello world');
+        $startDateTime = \date('Y-m-d H:i:s', strtotime($request->start));
+        $endDateTime = \date('Y-m-d H:i:s', strtotime($request->end));
+
+        $user = $request->user();
+        $trip = new Trip([
+            'name' => $request->name,
+            'description' => $request->description,
+            'start_date' => $startDateTime,
+            'end_date' => $endDateTime
+        ]);
+        $trip->save();
+        $trip->users()->save($user, [
+            'last_checked_trip' => now(),
+            'last_checked_chat' => now(),
+        ]);
+
+        $tripVm = $this->getTripVm($trip);
+        $tripVm['id'] = $trip->id;
+
+        $vm = [
+            'message' => 'Trip successfully created.',
+            'trip' => $tripVm
+        ];
+
+        return response()->json($vm);
     }
 
     /**

--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\CreateTripRequest;
 use App\Trip;
 use Illuminate\Http\Request;
 
@@ -9,7 +10,6 @@ class TripController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('auth:sanctum');
         // TODO: Incorporate Laravel Resources to transform Model to JSON
     }
 
@@ -128,12 +128,12 @@ class TripController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @param CreateTripRequest $request
+     * @return void
      */
-    public function store(Request $request)
+    public function store(CreateTripRequest $request)
     {
-        //
+        return response()->json('hello world');
     }
 
     /**

--- a/src/api/app/Http/Requests/CreateTripRequest.php
+++ b/src/api/app/Http/Requests/CreateTripRequest.php
@@ -4,6 +4,16 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * Class CreateTripRequest
+ * @package App\Http\Requests
+ *
+ * @property string name
+ * @property string description
+ * @property string start
+ * @property string end
+ */
+
 class CreateTripRequest extends FormRequest
 {
     /**

--- a/src/api/app/Http/Requests/CreateTripRequest.php
+++ b/src/api/app/Http/Requests/CreateTripRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateTripRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|string',
+            'description' => 'nullable|string',
+            'start' => 'required|date|after_or_equal:today',
+            'end' => 'required|date|after_or_equal:start'
+        ];
+    }
+}

--- a/src/api/app/Travel.php
+++ b/src/api/app/Travel.php
@@ -36,6 +36,8 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereToCoordinates($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereTripId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Travel whereUpdatedAt($value)
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\User[] $users
+ * @property-read int|null $users_count
  */
 class Travel extends Model
 {

--- a/src/api/app/Trip.php
+++ b/src/api/app/Trip.php
@@ -36,6 +36,13 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Trip extends Model
 {
+    protected $fillable = [
+        'name',
+        'description',
+        'start_date',
+        'end_date'
+    ];
+
     public function activities()
     {
         return $this->hasMany(Activity::class);

--- a/src/api/app/User.php
+++ b/src/api/app/User.php
@@ -39,6 +39,8 @@ use Illuminate\Notifications\Notifiable;
  * @property-read int|null $messages_count
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Activity[] $activities
  * @property-read int|null $activities_count
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Travel[] $travels
+ * @property-read int|null $travels_count
  */
 class User extends Authenticatable
 {

--- a/src/api/database/migrations/2020_04_24_052436_create_trips_table.php
+++ b/src/api/database/migrations/2020_04_24_052436_create_trips_table.php
@@ -17,7 +17,7 @@ class CreateTripsTable extends Migration
             $table->id();
 
             $table->string('name');
-            $table->text('description');
+            $table->text('description')->nullable();
             $table->dateTime('start_date');
             $table->dateTime('end_date');
 

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -18,6 +18,8 @@ Route::match('head', '/user/name/{user:name}', 'UserController@checkExists');
  * TripController
  */
 Route::get('/trips', 'TripController@index');
+Route::post('/trips', 'TripController@store');
+
 Route::get('/trips/past', 'TripController@pastTrips');
 Route::get('/trips/current', 'TripController@currentTrips');
 Route::get('/trips/future', 'TripController@futureTrips');

--- a/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
@@ -272,11 +272,11 @@ class TripControllerTest extends TestCase
         $this->assertEquals($trip->end_date, $response['end']);
 
         $response->assertJsonFragment([
-                'avatarPath' => $user->avatar_url,
-                'email' => $user->email,
-                'id' => $user->id,
-                'name' => $user->name,
-        );
+            'avatarPath' => $user->avatar_url,
+            'email' => $user->email,
+            'id' => $user->id,
+            'name' => $user->name,
+        ]);
     }
 
     /** @test */

--- a/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
@@ -256,6 +256,7 @@ class TripControllerTest extends TestCase
             ]);
     }
 
+
     public function joins_currently_logged_in_user_to_a_trip()
     {
         $user = factory(User::class)->create();
@@ -271,10 +272,75 @@ class TripControllerTest extends TestCase
         $this->assertEquals($trip->end_date, $response['end']);
 
         $response->assertJsonFragment([
-            'avatarPath' => $user->avatar_url,
-            'email' => $user->email,
-            'id' => $user->id,
-            'name' => $user->name,
+                'avatarPath' => $user->avatar_url,
+                'email' => $user->email,
+                'id' => $user->id,
+                'name' => $user->name,
+        );
+    }
+
+    /** @test */
+    public function creates_a_new_trip_unsuccessfully_when_start_date_is_before_today()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->json('post', '/api/trips', [
+            'name' => 'New Trip',
+            'description' => 'A new trip created for test purposes',
+            'start' => now()->addDays(-1)->toDateString(),
+            'end' => now()->toDateString()
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertDatabaseMissing('trips', [
+            'name' => 'New Trip',
+            'description' => 'A new trip created for test purposes'
+        ]);
+    }
+
+    /** @test */
+    public function creates_a_new_trip_unsuccessfully_when_end_date_is_before_start_date()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->json('post', '/api/trips', [
+            'name' => 'New Trip',
+            'description' => 'A new trip created for test purposes',
+            'start' => now()->toDateString(),
+            'end' => now()->addDays(-5)->toDateString()
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertDatabaseMissing('trips', [
+            'name' => 'New Trip',
+            'description' => 'A new trip created for test purposes'
+        ]);
+    }
+
+    /** @test */
+    public function creates_a_new_trip_with_valid_data()
+    {
+        $user = factory(User::class)->create();
+        $startDate = now()->toDateString();
+        $endDate = now()->addDays(1)->toDateString();
+
+        $response = $this->actingAs($user)->json('post', '/api/trips', [
+            'name' => 'New Trip',
+            'description' => 'A new trip created for test purposes',
+            'start' => $startDate,
+            'end' => $endDate
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('Trip successfully created.', $response['message']);
+        $this->assertEquals('New Trip', $response['trip']['name']);
+        $this->assertEquals('A new trip created for test purposes', $response['trip']['description']);
+        $this->assertEquals("$startDate 00:00:00", $response['trip']['start']);
+        $this->assertEquals("$endDate 00:00:00", $response['trip']['end']);
+        $this->assertEquals($user->id, $response['trip']['participants'][0]['id']);
+        $this->assertDatabaseHas('trips', [
+            'name' => 'New Trip',
+            'description' => 'A new trip created for test purposes'
         ]);
     }
 }


### PR DESCRIPTION
## Changes
- Adds a new API route `/api/trips` that expects a POST request with the following body:
```
{
  name: 'Trip name',
  description: 'Description',
  start: '2020-05-20',
  end: '2020-05-20'
}
```
- Upon submission, adds a new trip to the database and makes the current user a participant of the created trip

Closes #61.