### PR TITLE
API for adding Activities and Travels

### DIFF
--- a/src/api/app/Activity.php
+++ b/src/api/app/Activity.php
@@ -40,6 +40,15 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Activity extends Model
 {
+    protected $fillable = [
+        'type',
+        'name',
+        'description',
+        'start_time',
+        'end_time',
+        'trip_id'
+    ];
+
     /**
      * Gets the trip of this activity
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Activity;
 use App\Http\Requests\CreateActivityRequest;
+use App\Http\Requests\CreateTravelRequest;
 use App\Http\Requests\CreateTripRequest;
 use App\Location;
+use App\Travel;
 use App\Trip;
 use Illuminate\Http\Request;
 
@@ -291,6 +293,40 @@ class TripController extends Controller
         return $vmActivities;
     }
 
+    public function addTravel(CreateTravelRequest $request, Trip $trip)
+    {
+        $fromLocation = new Location([
+            'name' => $request->input('from.address'),
+            'address' => $request->input('from.address'),
+            'coordinates' => $request->input('from.lat') . ', ' . $request->input('from.lng')
+        ]);
+        $toLocation = new Location([
+            'name' => $request->input('to.address'),
+            'address' => $request->input('to.address'),
+            'coordinates' => $request->input('to.lat') . ', ' . $request->input('to.lng')
+        ]);
+        $fromLocation->save();
+        $toLocation->save();
+
+        $travel = new Travel([
+            'mode' => $request->input('mode'),
+            'description' => $request->input('description'),
+            'start' => date('Y-m-d H:i:s', strtotime($request->input('from.time'))),
+            'end' => date('Y-m-d H:i:s', strtotime($request->input('to.time'))),
+            'trip_id' => $trip->id,
+            'from_coordinates' => $request->input('from.lat') . ', ' . $request->input('from.lng'),
+            'to_coordinates' => $request->input('to.lat') . ', ' . $request->input('to.lng')
+        ]);
+        $travel->save();
+
+        $tripVm = $this->getTripVm($trip);
+
+        return response()->json([
+            'message' => "Successfully added a new Travel to $trip->name",
+            'trip' => $tripVm
+        ]);
+    }
+
     /**
      * Adds the currently logged in user as a participant to the given Trip
      * @param Request $request
@@ -314,6 +350,7 @@ class TripController extends Controller
     {
         $lat = $request->input('location.lat');
         $lng = $request->input('location.lng');
+
         $location = new Location([
             'name' => $request->input('location.address'),
             'address' => $request->input('location.address'),

--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -2,7 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Activity;
+use App\Http\Requests\CreateActivityRequest;
 use App\Http\Requests\CreateTripRequest;
+use App\Location;
 use App\Trip;
 use Illuminate\Http\Request;
 
@@ -303,6 +306,33 @@ class TripController extends Controller
 
         return response()->json([
             'message' => "Successfully added $user->email to $trip->name",
+            'trip' => $tripVm
+        ]);
+    }
+
+    public function addActivity(CreateActivityRequest $request, Trip $trip)
+    {
+        $lat = $request->input('location.lat');
+        $lng = $request->input('location.lng');
+        $location = new Location([
+            'name' => $request->input('location.address'),
+            'address' => $request->input('location.address'),
+            'coordinates' => "$lat, $lng"
+        ]);
+        $location->save();
+        $location->activities()->create([
+            'type' => $request->type,
+            'name' => $request->name,
+            'description' => $request->description,
+            'start_time' => date('Y-m-d H:i:s', strtotime($request->start)),
+            'end_time' => date('Y-m-d H:i:s', strtotime($request->end)),
+            'trip_id' => $trip->id,
+        ]);
+
+        $tripVm = $this->getTripVm($trip);
+
+        return response()->json([
+            'message' => "Successfully added $trip->name to database.",
             'trip' => $tripVm
         ]);
     }

--- a/src/api/app/Http/Controllers/TripController.php
+++ b/src/api/app/Http/Controllers/TripController.php
@@ -352,8 +352,8 @@ class TripController extends Controller
         $lng = $request->input('location.lng');
 
         $location = new Location([
-            'name' => $request->input('location.address'),
-            'address' => $request->input('location.address'),
+            'name' => $request->input('location.address', 'Unknown Address'),
+            'address' => $request->input('location.address', 'Unknown Address'),
             'coordinates' => "$lat, $lng"
         ]);
         $location->save();

--- a/src/api/app/Http/Requests/CreateActivityRequest.php
+++ b/src/api/app/Http/Requests/CreateActivityRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Class CreateActivityRequest
+ * @package App\Http\Requests
+ * @property string name
+ * @property string type
+ * @property string start
+ * @property string end
+ * @property string description
+ * @property mixed location
+ */
+
+class CreateActivityRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'string|required',
+            'type' => 'string|required|in:outdoors,eating,scenery,gathering,music,gamble,play,fantasy,landmark,art,animal',
+            'start' => ['date',
+                // RFC3339 RegEx
+                'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
+                '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
+                '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/i'
+            ],
+            'end' => ['date',
+                // RFC3339 RegEx
+                'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
+                '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
+                '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/i'
+            ],
+            'description' => 'string|nullable',
+            'location.lat' => 'string|required',
+            'location.lng' => 'string|required',
+            'location.address' => 'string|nullable'
+        ];
+    }
+}

--- a/src/api/app/Http/Requests/CreateActivityRequest.php
+++ b/src/api/app/Http/Requests/CreateActivityRequest.php
@@ -37,13 +37,13 @@ class CreateActivityRequest extends FormRequest
         return [
             'name' => 'string|required',
             'type' => 'string|required|in:outdoors,eating,scenery,gathering,music,gamble,play,fantasy,landmark,art,animal',
-            'start' => ['date',
+            'start' => ['date', 'required',
                 // RFC3339 RegEx
                 'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
                 '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
                 '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/i'
             ],
-            'end' => ['date',
+            'end' => ['date', 'required', 'after:start',
                 // RFC3339 RegEx
                 'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
                 '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .

--- a/src/api/app/Http/Requests/CreateTravelRequest.php
+++ b/src/api/app/Http/Requests/CreateTravelRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateTravelRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'mode' => 'string|in:bus,plane,car,ship,motorcycle,train,bicycle,walk,horse',
+            'description' => 'string|nullable',
+            'from.lat' => 'string',
+            'from.lng' => 'string',
+            'from.address' => 'string',
+            'from.time' => [
+                'date',
+                // RFC3339 RegEx
+                'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
+                '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
+                '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/i'
+            ],
+            'to.lat' => 'string',
+            'to.lng' => 'string',
+            'to.address' => 'string',
+            'to.time' => [
+                'date',
+                // RFC3339 RegEx
+                'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
+                '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
+                '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/i'
+            ],
+        ];
+    }
+}

--- a/src/api/app/Http/Requests/CreateTravelRequest.php
+++ b/src/api/app/Http/Requests/CreateTravelRequest.php
@@ -24,23 +24,23 @@ class CreateTravelRequest extends FormRequest
     public function rules()
     {
         return [
-            'mode' => 'string|in:bus,plane,car,ship,motorcycle,train,bicycle,walk,horse',
+            'mode' => 'string|in:bus,plane,car,ship,motorcycle,train,bicycle,walk,horse|required',
             'description' => 'string|nullable',
-            'from.lat' => 'string',
-            'from.lng' => 'string',
+            'from.lat' => 'string|required',
+            'from.lng' => 'string|required',
             'from.address' => 'string',
             'from.time' => [
-                'date',
+                'date', 'required',
                 // RFC3339 RegEx
                 'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
                 '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
                 '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/i'
             ],
-            'to.lat' => 'string',
-            'to.lng' => 'string',
+            'to.lat' => 'string|required',
+            'to.lng' => 'string|required',
             'to.address' => 'string',
             'to.time' => [
-                'date',
+                'date', 'after:from.time', 'required',
                 // RFC3339 RegEx
                 'regex:' . '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
                 '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .

--- a/src/api/app/Location.php
+++ b/src/api/app/Location.php
@@ -28,4 +28,14 @@ class Location extends Model
 {
     protected $primaryKey = 'coordinates';
     public $incrementing = false;
+    protected $fillable = [
+        'name',
+        'address',
+        'coordinates'
+    ];
+
+    public function activities()
+    {
+        return $this->hasMany(Activity::class, 'location_coordinates');
+    }
 }

--- a/src/api/app/Travel.php
+++ b/src/api/app/Travel.php
@@ -41,6 +41,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Travel extends Model
 {
+    protected $guarded = [];
+
     /**
      * Gets the trip of this travel path
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/api/database/migrations/2020_04_24_055041_create_user_trip_table.php
+++ b/src/api/database/migrations/2020_04_24_055041_create_user_trip_table.php
@@ -16,8 +16,8 @@ class CreateUserTripTable extends Migration
         Schema::create('user_trip', function (Blueprint $table) {
             $table->id();
 
-            $table->dateTime('last_checked_trip');
-            $table->dateTime('last_checked_chat');
+            $table->dateTime('last_checked_trip')->nullable();
+            $table->dateTime('last_checked_chat')->nullable();
 
             $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('trip_id');

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -32,5 +32,6 @@ Route::get('/trip/{trip}/activities', 'TripController@showActivities');
 Route::post('/trip/{trip}/activities', 'TripController@addActivity');
 
 Route::get('/trip/{trip}/travels', 'TripController@showTravels');
+Route::post('/trip/{trip}/travels', 'TripController@addTravel');
 
 

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -25,8 +25,12 @@ Route::get('/trips/current', 'TripController@currentTrips');
 Route::get('/trips/future', 'TripController@futureTrips');
 
 Route::get('/trip/{trip}', 'TripController@show');
+
 Route::post('/trip/{trip}/users', 'TripController@addUser');
+
 Route::get('/trip/{trip}/activities', 'TripController@showActivities');
+Route::post('/trip/{trip}/activities', 'TripController@addActivity');
+
 Route::get('/trip/{trip}/travels', 'TripController@showTravels');
 
 

--- a/src/api/tests/Feature/GeneralTest.php
+++ b/src/api/tests/Feature/GeneralTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class GeneralTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function db_entities_get_added_with_timezone_zulu_by_default()
+    {
+        $response = $this->json('post', "/api/register", [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+            'password' => 'newUserPassword',
+            'password_confirmation' => 'newUserPassword',
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'newuser@user.com',
+            'name' => 'New User',
+            'created_at' => now(new \DateTimeZone('Zulu'))
+        ]);
+    }
+}

--- a/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
@@ -343,4 +343,36 @@ class TripControllerTest extends TestCase
             'description' => 'A new trip created for test purposes'
         ]);
     }
+
+    /** @test */
+    public function creates_a_new_activity_for_a_trip()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $trip->users()->save($user);
+
+        $response = $this->actingAs($user)->json('post', "/api/trip/$trip->id/activities", [
+            'name' => 'Activity name here',
+            'type' => 'outdoors',
+            'start' => '2020-05-20T07:20:50.52Z',
+            'end' => '2020-05-20T07:22:50.52Z',
+            'description' => 'Activity description here',
+            'location' => [
+                'lat' => '-36.880765',
+                'lng' => '174.801228',
+                'address' => '10 Some Street, Auckland, 1010 Auckland'
+            ],
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('activities', [
+            'name' => 'Activity name here',
+            'type' => 'outdoors',
+            'start_time' => '2020-05-20 07:20:50',
+            'end_time' => '2020-05-20 07:22:50',
+            'description' => 'Activity description here',
+            'location_coordinates' => '-36.880765, 174.801228',
+            'trip_id' => $trip->id
+        ]);
+    }
 }

--- a/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
@@ -377,6 +377,165 @@ class TripControllerTest extends TestCase
     }
 
     /** @test */
+    public function created_activity_does_not_contain_participants()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $trip->users()->save($user);
+
+        $response = $this->actingAs($user)->json('post', "/api/trip/$trip->id/activities", [
+            'name' => 'Activity name here',
+            'type' => 'outdoors',
+            'start' => '2020-05-20T07:20:50.52Z',
+            'end' => '2020-05-20T07:22:50.52Z',
+            'description' => 'Activity description here',
+            'location' => [
+                'lat' => '-36.880765',
+                'lng' => '174.801228',
+                'address' => '10 Some Street, Auckland, 1010 Auckland'
+            ],
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('user_pointer', [
+            'user_id' => $user->id,
+            'pointer_type' => Activity::class
+        ]);
+    }
+
+    /** @test */
+    public function rejects_activity_creation_when_required_fields_are_missing()
+    {
+        $requestBodies = [
+            [
+                'type' => 'outdoors',
+                'start' => '2020-05-20T07:20:50.52Z',
+                'end' => '2020-05-20T07:22:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ]
+            ],
+            [
+                'name' => 'Activity name here',
+                'start' => '2020-05-20T07:20:50.52Z',
+                'end' => '2020-05-20T07:22:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ]
+            ],
+            [
+                'name' => 'Activity name here',
+                'type' => 'outdoors',
+                'end' => '2020-05-20T07:22:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ]
+            ],
+            [
+                'name' => 'Activity name here',
+                'type' => 'outdoors',
+                'start' => '2020-05-20T07:20:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ]
+            ],
+            [
+                'name' => 'Activity name here',
+                'type' => 'outdoors',
+                'start' => '2020-05-20T07:20:50.52Z',
+                'end' => '2020-05-20T07:22:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ]
+            ],
+            [
+                'name' => 'Activity name here',
+                'type' => 'outdoors',
+                'start' => '2020-05-20T07:20:50.52Z',
+                'end' => '2020-05-20T07:22:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lat' => '-36.880765',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ]
+            ]
+        ];
+
+        foreach ($requestBodies as $requestBody) {
+            $user = factory(User::class)->create();
+            $trip = factory(Trip::class)->create();
+            $trip->users()->save($user);
+
+            $response = $this->actingAs($user)
+                ->json('post', "/api/trip/$trip->id/activities", $requestBody);
+
+            $response->assertStatus(422);
+        }
+    }
+
+    /** @test */
+    public function rejects_activity_creation_when_end_time_is_on_start_time()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $trip->users()->save($user);
+
+        $response = $this->actingAs($user)
+            ->json('post', "/api/trip/$trip->id/activities", [
+                'name' => 'Activity name here',
+                'type' => 'outdoors',
+                'start' => '2020-05-20T07:20:50.52Z',
+                'end' => '2020-05-20T07:20:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ],
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function rejects_activity_creation_when_end_time_is_before_start_time()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $trip->users()->save($user);
+
+        $response = $this->actingAs($user)
+            ->json('post', "/api/trip/$trip->id/activities", [
+                'name' => 'Activity name here',
+                'type' => 'outdoors',
+                'start' => '2020-05-20T07:20:50.52Z',
+                'end' => '2020-05-20T06:20:50.52Z',
+                'description' => 'Activity description here',
+                'location' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland'
+                ],
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
     public function creates_a_new_travel_for_a_trip()
     {
         $user = factory(User::class)->create();
@@ -410,5 +569,184 @@ class TripControllerTest extends TestCase
             'from_coordinates' => "-36.880765, 174.801228",
             'to_coordinates' => "-36.880765, 175.801228",
         ]);
+    }
+
+    /** @test */
+    public function rejects_travel_creation_when_to_time_is_before_from_time()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $trip->users()->save($user);
+
+        $response = $this->actingAs($user)
+            ->json('post', "/api/trip/$trip->id/travels", [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T06:20:50.52Z',
+                ]
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function rejects_travel_creation_when_to_time_is_equal_to_from_time()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $trip->users()->save($user);
+
+        $response = $this->actingAs($user)
+            ->json('post', "/api/trip/$trip->id/travels", [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ]
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function rejects_travel_creation_when_required_fields_are_missing()
+    {
+        $requestBodies = [
+            [
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ]
+            ],
+            [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ]
+            ],
+            [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ]
+            ],
+            [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ]
+            ],
+            [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ]
+            ],
+            [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ]
+            ],
+            [
+                'mode' => 'bus',
+                'description' => 'Travel description',
+                'from' => [
+                    'lat' => '-36.880765',
+                    'lng' => '174.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                    'time' => '2020-05-20T07:20:50.52Z',
+                ],
+                'to' => [
+                    'lat' => '-36.880765',
+                    'lng' => '175.801228',
+                    'address' => '10 Some Street, Auckland, 1010 Auckland',
+                ]
+            ],
+        ];
+
+        foreach ($requestBodies as $requestBody) {
+            $user = factory(User::class)->create();
+            $trip = factory(Trip::class)->create();
+            $trip->users()->save($user);
+
+            $response = $this->actingAs($user)
+                ->json('post', "/api/trip/$trip->id/travels", $requestBody);
+
+            $response->assertStatus(422);
+        }
     }
 }

--- a/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TripControllerTest.php
@@ -375,4 +375,40 @@ class TripControllerTest extends TestCase
             'trip_id' => $trip->id
         ]);
     }
+
+    /** @test */
+    public function creates_a_new_travel_for_a_trip()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $trip->users()->save($user);
+
+        $response = $this->actingAs($user)->json('post', "/api/trip/$trip->id/travels", [
+            'mode' => 'bus',
+            'description' => 'Travel description',
+            'from' => [
+                'lat' => '-36.880765',
+                'lng' => '174.801228',
+                'address' => '10 Some Street, Auckland, 1010 Auckland',
+                'time' => '2020-05-20T07:20:50.52Z',
+            ],
+            'to' => [
+                'lat' => '-36.880765',
+                'lng' => '175.801228',
+                'address' => '10 Some Street, Auckland, 1010 Auckland',
+                'time' => '2020-05-20T09:20:50.52Z',
+            ]
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('travels', [
+            'mode' => 'bus',
+            'description' => 'Travel description',
+            'start' => '2020-05-20 07:20:50',
+            'end' => '2020-05-20 09:20:50',
+            'trip_id' => $trip->id,
+            'from_coordinates' => "-36.880765, 174.801228",
+            'to_coordinates' => "-36.880765, 175.801228",
+        ]);
+    }
 }


### PR DESCRIPTION
## Changes
- Adds a new route `/api/trip/{trip-id}/activities` that expects a POST request as follows:
```
{
  name: '',
  type: '',
  start: '2020-05-20T07:20:50.52Z' // RFC3339 compliant,
  end: '2020-05-21T07:20:50.52Z' // RFC3339 compliant.
  description: '',
  location: {
    lat: '',
    lng: '',
    address: '',
  }
}
```

- Adds a new route `/api/trip/{trip-id}/travels` that expects a POST request as follows:
```
{
  mode: '',
  description: '',
  from: {
    lat: '',
    lng: '',
    address: '',
    time: '2020-05-20T07:20:50.52Z' // RFC3339 compliant,
  }
  to: {
    lat: '',
    lng: '',
    address: '',
    time: '2020-05-21T07:20:50.52Z' // RFC3339 compliant,
  }
}
```

Closes #67 