### PR TITLE
Serve Next.js app through nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ TripTime is an application for groups of friends to plan a trip together. Users 
 Before executing the commands below, ensure that you are in the same directory as `docker-compose.yml`.
 
 ### Development
-To run the web application with hot module reload, execute the following command and go to http://localhost:3000. The Laravel application is located at http://localhost:8080
+To run the web application with hot module reload, execute the following command and go to http://localhost:3000.
 ```shell script
 $ docker-compose up
 ```
 
 ### Development (API only)
-To run the API only, execute the following command
+To run the API only (served on http://localhost:8080/), execute the following command:
 ```shell script
 $ docker-compose -f docker-compose.api-only.yml up
 ```
@@ -50,7 +50,7 @@ $ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 This deploys all three services using the configuration in `docker-compose.yml` and `docker-compose.prod.yml` (but not the dev configuration in `docker-compose.override.yml`).
 
-The Next.js application will be served on http://localhost and the Laravel application on http://localhost:8080
+The application will be served on http://localhost
 
 ### Termination
 

--- a/docker-compose.api-only.yml
+++ b/docker-compose.api-only.yml
@@ -5,18 +5,24 @@ networks:
 
 services:
   api:
-    image: nginx:stable-alpine
+    image: nginx:1.17-alpine
     container_name: api-laravel
     ports:
       - "8080:80"
     volumes:
       - ./src/api:/var/www/html
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/api-only.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - php
       - mysql
     networks:
       - triptime
+    restart: always
+    healthcheck:
+      test: curl --fail -s http://localhost:80 || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 2
 
   mysql:
     image: mysql:5.7.29

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,10 +5,11 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-    ports:
-      - "3000:3000"
     volumes:
       - ./src/spa:/usr/app/
       - ./src/spa/node_modules:/usr/app/node_modules
       - /usr/app/.next
     command: npm run dev
+  api:
+    ports:
+      - "3000:80"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-    ports:
-      - "80:3000"
     command: npm start
+  api:
+    ports:
+      - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     build:
       context: ./src/spa
       dockerfile: Dockerfile
-    depends_on:
-      - api
     restart: always
     networks:
       - triptime
@@ -28,8 +26,10 @@ services:
     depends_on:
       - php
       - mysql
+      - spa
     networks:
       - triptime
+    restart: always
     healthcheck:
       test: curl --fail -s http://localhost:80 || exit 1
       interval: 30s

--- a/nginx/api-only.conf
+++ b/nginx/api-only.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    index index.php index.html;
+    server_name localhost;
+    error_log  stderr warn;
+    access_log /dev/stdout main;
+    root /var/www/html/public;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,12 +1,71 @@
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=7d use_temp_path=off;
+
+upstream nextjs_upstream {
+    server spa:3000;
+}
+
 server {
     listen 80;
-    index index.php index.html;
+
     server_name localhost;
+    server_tokens off;
+
     error_log  stderr warn;
     access_log /dev/stdout main;
+
+    index index.php index.html;
+
     root /var/www/html/public;
 
+    gzip on;
+    gzip_proxied any;
+    gzip_comp_level 4;
+    gzip_types text/css application/javascript image/svg+xml;
+
     location / {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_pass http://nextjs_upstream;
+    }
+
+    location /_next/static {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+
+        proxy_cache STATIC;
+        proxy_pass http://nextjs_upstream;
+
+        # For testing cache - remove before deploying to production
+        add_header X-Cache-Status $upstream_cache_status;
+    }
+
+    location /static {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+
+        proxy_cache STATIC;
+        proxy_ignore_headers Cache-Control;
+        proxy_cache_valid 60m;
+        proxy_pass http://nextjs_upstream;
+
+        # For testing cache - remove before deploying to production
+        add_header X-Cache-Status $upstream_cache_status;
+    }
+
+    location /api {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location /sanctum {
         try_files $uri $uri/ /index.php?$query_string;
     }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -22,13 +22,12 @@ server {
     gzip_comp_level 4;
     gzip_types text/css application/javascript image/svg+xml;
 
-    location / {
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
-        proxy_pass http://nextjs_upstream;
+    location /api {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location /sanctum {
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     location /_next/static {
@@ -40,9 +39,6 @@ server {
 
         proxy_cache STATIC;
         proxy_pass http://nextjs_upstream;
-
-        # For testing cache - remove before deploying to production
-        add_header X-Cache-Status $upstream_cache_status;
     }
 
     location /static {
@@ -56,17 +52,16 @@ server {
         proxy_ignore_headers Cache-Control;
         proxy_cache_valid 60m;
         proxy_pass http://nextjs_upstream;
-
-        # For testing cache - remove before deploying to production
-        add_header X-Cache-Status $upstream_cache_status;
     }
 
-    location /api {
-        try_files $uri $uri/ /index.php?$query_string;
-    }
+    location / {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
 
-    location /sanctum {
-        try_files $uri $uri/ /index.php?$query_string;
+        proxy_pass http://nextjs_upstream;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
## Changes
- Next.js app is now served through nginx webserver at `http://localhost:3000` for DEV and `http://localhost` for PROD
- Laravel app is now served through `http:://localhost:3000/api` and `http:://localhost:3000/sanctum`
- Pages are gzip compressed before serving to client
- Built static assets by Next.js are cached by nginx

Closes #44 