### PR TITLE
API to create and update notes tied to Travels/Activities

### DIFF
--- a/src/api/app/Http/Controllers/ActivityController.php
+++ b/src/api/app/Http/Controllers/ActivityController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Activity;
 use App\Http\Resources\NoteCollection;
+use App\Http\Resources\NoteResource;
+use App\Http\Resources\UserResource;
+use App\Note;
 use Illuminate\Http\Request;
 
 class ActivityController extends Controller
@@ -65,6 +68,33 @@ class ActivityController extends Controller
         $notes = $activity->notes()->get();
 
         return new NoteCollection($notes);
+    }
+
+    /**
+     * Adds a note to the given activity
+     * @param Request $request
+     * @param Activity $activity
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function addNote(Request $request, Activity $activity)
+    {
+        $request->validate([
+            'content' => 'string|required'
+        ]);
+
+        $note = new Note([
+            'body' => $request->input('content'),
+            'user_id' => $request->user()->id
+        ]);
+
+        $activity->notes()->save($note);
+
+        $vm = [
+            'message' => "Successfully added note to \"$activity->name\"",
+            'note' => new NoteResource($note)
+        ];
+
+        return response()->json($vm);
     }
 
     /**

--- a/src/api/app/Http/Controllers/ActivityController.php
+++ b/src/api/app/Http/Controllers/ActivityController.php
@@ -98,6 +98,36 @@ class ActivityController extends Controller
     }
 
     /**
+     * Updates the currently logged in user's note tied to the given activity
+     * @param Request $request
+     * @param Activity $activity
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function updateNote(Request $request, Activity $activity)
+    {
+        $request->validate([
+            'content' => 'string|required'
+        ]);
+
+        $user = $request->user();
+
+        $note = Note::where([
+            ['user_id', $user->id],
+            ['pointer_type', Activity::class],
+            ['pointer_id', $activity->id],
+        ])->first();
+        $note->body = $request->input('content');
+        $note->save();
+
+        $vm = [
+            'message' => "Successfully updated note for \"$activity->name\"",
+            'note' => new NoteResource($note)
+        ];
+
+        return response()->json($vm);
+    }
+
+    /**
      * Show the form for editing the specified resource.
      *
      * @param  \App\Activity  $activity

--- a/src/api/app/Http/Controllers/TravelController.php
+++ b/src/api/app/Http/Controllers/TravelController.php
@@ -84,7 +84,37 @@ class TravelController extends Controller
         $travel->notes()->save($note);
 
         $vm = [
-            'message' => "Successfully added note to \"$travel->name\"",
+            'message' => "Successfully added note.",
+            'note' => new NoteResource($note)
+        ];
+
+        return response()->json($vm);
+    }
+
+    /**
+     * Updates the currently logged in user's note tied to the given activity
+     * @param Request $request
+     * @param Travel $travel
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function updateNote(Request $request, Travel $travel)
+    {
+        $request->validate([
+            'content' => 'string|required'
+        ]);
+
+        $user = $request->user();
+
+        $note = Note::where([
+            ['user_id', $user->id],
+            ['pointer_type', Travel::class],
+            ['pointer_id', $travel->id],
+        ])->first();
+        $note->body = $request->input('content');
+        $note->save();
+
+        $vm = [
+            'message' => "Successfully updated note.",
             'note' => new NoteResource($note)
         ];
 

--- a/src/api/app/Http/Controllers/TravelController.php
+++ b/src/api/app/Http/Controllers/TravelController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Http\Resources\NoteCollection;
+use App\Http\Resources\NoteResource;
+use App\Note;
 use App\Travel;
 use Illuminate\Http\Request;
 
@@ -50,11 +52,43 @@ class TravelController extends Controller
         //
     }
 
+    /**
+     * Displays all Notes tied to this Travel
+     * @param Travel $travel
+     * @return NoteCollection
+     */
     public function showNotes(Travel $travel)
     {
         $notes = $travel->notes()->get();
 
         return new NoteCollection($notes);
+    }
+
+    /**
+     * Adds a Note to the given Travel
+     * @param Request $request
+     * @param Travel $travel
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function addNote(Request $request, Travel $travel)
+    {
+        $request->validate([
+            'content' => 'string|required'
+        ]);
+
+        $note = new Note([
+            'body' => $request->input('content'),
+            'user_id' => $request->user()->id
+        ]);
+
+        $travel->notes()->save($note);
+
+        $vm = [
+            'message' => "Successfully added note to \"$travel->name\"",
+            'note' => new NoteResource($note)
+        ];
+
+        return response()->json($vm);
     }
 
     /**

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -17,6 +17,7 @@ Route::post('/activity/{activity}/notes', 'ActivityController@addNote');
  * TravelController
  */
 Route::get('/travel/{travel}/notes', 'TravelController@showNotes');
+Route::post('/travel/{travel}/notes', 'TravelController@addNote');
 
 /*
  * TripController

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -12,6 +12,7 @@ Route::get('/logout', 'Auth\LoginController@logout');
  */
 Route::get('/activity/{activity}/notes', 'ActivityController@showNotes');
 Route::post('/activity/{activity}/notes', 'ActivityController@addNote');
+Route::patch('/activity/{activity}/notes', 'ActivityController@updateNote');
 
 /*
  * TravelController

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -11,6 +11,7 @@ Route::get('/logout', 'Auth\LoginController@logout');
  * ActivityController
  */
 Route::get('/activity/{activity}/notes', 'ActivityController@showNotes');
+Route::post('/activity/{activity}/notes', 'ActivityController@addNote');
 
 /*
  * TravelController

--- a/src/api/routes/api.php
+++ b/src/api/routes/api.php
@@ -19,6 +19,7 @@ Route::patch('/activity/{activity}/notes', 'ActivityController@updateNote');
  */
 Route::get('/travel/{travel}/notes', 'TravelController@showNotes');
 Route::post('/travel/{travel}/notes', 'TravelController@addNote');
+Route::patch('/travel/{travel}/notes', 'TravelController@updateNote');
 
 /*
  * TripController

--- a/src/api/tests/Feature/Http/Controllers/ActivityControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/ActivityControllerTest.php
@@ -49,4 +49,42 @@ class ActivityControllerTest extends TestCase
             'updated' => date(DATE_RFC3339, strtotime($note->updated_at))
         ]);
     }
+
+    /** @test */
+    public function creates_notes_tied_to_an_activity()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $location = factory(Location::class)->create([
+            'coordinates' => '100.22, 20.36'
+        ]);
+        $activity = factory(Activity::class)->create();
+        $user->activities()->attach($activity);
+
+        $response = $this->actingAs($user)
+            ->json('post', "/api/activity/$activity->id/notes", [
+                'content' => 'Test note contents here'
+            ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'message' => "Successfully added note to \"$activity->name\"",
+            'note' => [
+                'author' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'avatarPath' => $user->avatar_url,
+                ],
+                'content' => 'Test note contents here',
+                'updated' => date(DATE_RFC3339, strtotime(now()->toDateTimeString()))
+            ]
+        ]);
+        $this->assertDatabaseHas('notes', [
+            'body' => 'Test note contents here',
+            'user_id' => $user->id,
+            'pointer_id' => $activity->id,
+            'pointer_type' => Activity::class
+        ]);
+    }
 }

--- a/src/api/tests/Feature/Http/Controllers/ActivityControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/ActivityControllerTest.php
@@ -87,4 +87,46 @@ class ActivityControllerTest extends TestCase
             'pointer_type' => Activity::class
         ]);
     }
+
+    /** @test */
+    public function updates_existing_user_added_note_tied_to_an_activity()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $location = factory(Location::class)->create([
+            'coordinates' => '100.22, 20.36'
+        ]);
+        $activity = factory(Activity::class)->create();
+        $user->activities()->attach($activity);
+        $note = new Note([
+            'body' => 'Test body',
+            'user_id' => $user->id,
+            'pointer_id' => $activity->id,
+            'pointer_type' => Activity::class
+        ]);
+        $note->save();
+
+        $response = $this->actingAs($user)
+            ->json('patch', "/api/activity/$activity->id/notes", [
+                'content' => 'My new note content'
+            ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'author' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'avatarPath' => $user->avatar_url,
+            ],
+            'content' => 'My new note content',
+            'updated' => date(DATE_RFC3339, strtotime($note->updated_at))
+        ]);
+        $this->assertDatabaseHas('notes', [
+            'body' => 'My new note content',
+            'user_id' => $user->id,
+            'pointer_id' => $activity->id,
+            'pointer_type' => Activity::class
+        ]);
+    }
 }

--- a/src/api/tests/Feature/Http/Controllers/TravelControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TravelControllerTest.php
@@ -49,4 +49,42 @@ class TravelControllerTest extends TestCase
             'updated' => date(DATE_RFC3339, strtotime($note->updated_at))
         ]);
     }
+
+    /** @test */
+    public function creates_notes_tied_to_a_travel()
+    {
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $location = factory(Location::class)->create([
+            'coordinates' => '100.22, 20.36'
+        ]);
+        $travel = factory(Travel::class)->create();
+        $user->activities()->attach($travel);
+
+        $response = $this->actingAs($user)
+            ->json('post', "/api/travel/$travel->id/notes", [
+                'content' => 'Test note contents here'
+            ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'message' => "Successfully added note to \"$travel->name\"",
+            'note' => [
+                'author' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'avatarPath' => $user->avatar_url,
+                ],
+                'content' => 'Test note contents here',
+                'updated' => date(DATE_RFC3339, strtotime(now()->toDateTimeString()))
+            ]
+        ]);
+        $this->assertDatabaseHas('notes', [
+            'body' => 'Test note contents here',
+            'user_id' => $user->id,
+            'pointer_id' => $travel->id,
+            'pointer_type' => Travel::class
+        ]);
+    }
 }

--- a/src/api/tests/Feature/Http/Controllers/TravelControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TravelControllerTest.php
@@ -68,7 +68,7 @@ class TravelControllerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJsonFragment([
-            'message' => "Successfully added note to \"$travel->name\"",
+            'message' => "Successfully added note.",
             'note' => [
                 'author' => [
                     'id' => $user->id,

--- a/src/api/tests/Feature/Http/Controllers/TravelControllerTest.php
+++ b/src/api/tests/Feature/Http/Controllers/TravelControllerTest.php
@@ -7,6 +7,7 @@ use App\Note;
 use App\Travel;
 use App\Trip;
 use App\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -127,6 +128,68 @@ class TravelControllerTest extends TestCase
             'user_id' => $user->id,
             'pointer_id' => $travel->id,
             'pointer_type' => Travel::class
+        ]);
+    }
+
+    /** @test */
+    public function updated_notes_have_updated_timestamp_changed()
+    {
+        // Set "current time" for this test to a specific datetime
+        Carbon::setTestNow(Carbon::create(2020, 1, 1));
+
+        $user = factory(User::class)->create();
+        $trip = factory(Trip::class)->create();
+        $location = factory(Location::class)->create([
+            'coordinates' => '100.22, 20.36'
+        ]);
+        $travel = factory(Travel::class)->create();
+        $user->travels()->attach($travel);
+        $note = new Note([
+            'body' => 'Test body',
+            'user_id' => $user->id,
+            'pointer_id' => $travel->id,
+            'pointer_type' => Travel::class
+        ]);
+        $note->created_at = Carbon::now(); // Create using set datetime earlier
+        $note->updated_at = Carbon::now(); // Create using set datetime earlier
+        $note->save();
+
+        // Check that the created note is really in the past
+        $this->assertDatabaseHas('notes', [
+            'body' => 'Test body',
+            'user_id' => $user->id,
+            'pointer_id' => $travel->id,
+            'pointer_type' => Travel::class,
+            'created_at' => '2020-01-01 00:00:00',
+            'updated_at' => '2020-01-01 00:00:00',
+        ]);
+
+        // Clear mocked date
+        Carbon::setTestNow();
+
+        $response = $this->actingAs($user)
+            ->json('patch', "/api/travel/$travel->id/notes", [
+                'content' => 'My new note content'
+            ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'author' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'avatarPath' => $user->avatar_url,
+            ],
+            'content' => 'My new note content',
+            'updated' => date(DATE_RFC3339, strtotime(now()))
+        ]);
+        $this->assertDatabaseHas('notes', [
+            'body' => 'My new note content',
+            'user_id' => $user->id,
+            'pointer_id' => $travel->id,
+            'pointer_type' => Travel::class,
+            'created_at' => '2020-01-01 00:00:00',
+            'updated_at' => Carbon::now()
         ]);
     }
 }


### PR DESCRIPTION
## Changes
- New POST route `/api/activity/{activity-ID}/notes` for creating activity note that expects request body:
```
{
  content: 'New note here'
}
```
- New PATCH route `/api/activity/{activity-ID}/notes` for updating activity note for currently logged in user that expects body:
```
{
  content: 'Change my last created note'
}
```
- New POST route `/api/travel/{travel-ID}/notes` for creating travel note that expects request body:
```
{
  content: 'New note here'
}
```
- New PATCH route `/api/travel/{travel-ID}/notes` for updating travel note for currently logged in user that expects body:
```
{
  content: 'Change my last created note'
}
```

Closes #69 